### PR TITLE
Add beefy dependency support and --all

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "diener"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "cargo_metadata",
  "git-url-parse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diener"
-version = "0.3.3"
+version = "0.4.0"
 authors = ["Bastian Köcher <git@kchr.de>"]
 edition = "2018"
 categories = [ "command-line-utilities" ]
@@ -9,7 +9,7 @@ repository = "https://github.com/bkchr/diener"
 keywords = [ "cli", "substrate", "polkadot" ]
 license = "Apache-2.0/MIT"
 description = """
-dependency diener is a tool for easily changing [Substrate](https://github.com/paritytech/substrate) or [Polkadot](https://github.com/paritytech/polkadot) dependency versions
+dependency diener is a tool for easily changing [Substrate](https://github.com/paritytech/substrate), [Polkadot](https://github.com/paritytech/polkadot) or [BEEFY](https://github.com/paritytech/grandpa-bridge-gadget) dependency versions
 """
 readme = "./README.md"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ enum SubCommands {
 /// Cli options of Diener
 #[derive(Debug, StructOpt)]
 #[structopt(
-    about = "Diener - dependency diener for replacing substrate or polkadot versions in `Cargo.toml` files"
+    about = "Diener - dependency diener for replacing substrate, polkadot or beefy versions in `Cargo.toml` files"
 )]
 struct Options {
     #[structopt(subcommand)]

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -105,7 +105,7 @@ pub struct Patch {
     /// The target is `[patch.TARGET]` in the final `Cargo.toml`.
     #[structopt(
         long,
-        conflicts_with_all = &[ "crates", "substrate", "polkadot" ]
+        conflicts_with_all = &[ "crates", "substrate", "polkadot", "beefy" ]
     )]
     target: Option<String>,
 
@@ -113,7 +113,7 @@ pub struct Patch {
     #[structopt(
         long,
         short = "s",
-        conflicts_with_all = &[ "target", "polkadot", "crates" ]
+        conflicts_with_all = &[ "target", "polkadot", "crates", "beefy" ]
     )]
     substrate: bool,
 
@@ -121,14 +121,22 @@ pub struct Patch {
     #[structopt(
         long,
         short = "p",
-        conflicts_with_all = &[ "target", "substrate", "crates" ]
+        conflicts_with_all = &[ "target", "substrate", "crates", "beefy" ]
     )]
     polkadot: bool,
+
+    /// Use the official BEEFY repo as patch target.
+    #[structopt(
+        long,
+        short = "b",
+        conflicts_with_all = &[ "target", "substrate", "crates", "polkadot" ]
+    )]
+    beefy: bool,
 
     /// Use `crates.io` as patch target.
     #[structopt(
         long,
-        conflicts_with_all = &[ "target", "substrate", "polkadot" ]
+        conflicts_with_all = &[ "target", "substrate", "polkadot", "beefy" ]
     )]
     crates: bool,
 }
@@ -179,10 +187,14 @@ impl Patch {
             Ok(PatchTarget::Git(
                 "https://github.com/paritytech/polkadot".into(),
             ))
+        } else if self.beefy {
+            Ok(PatchTarget::Git(
+                "https://github.com/paritytech/parity-bridges-gadget".into(),
+            ))
         } else if self.crates {
             Ok(PatchTarget::Crates)
         } else {
-            Err("You need to pass `--target`, `--substrate`, `--polkadot` or `--crates`!".into())
+            Err("You need to pass `--target`, `--substrate`, `--polkadot`, `--beefy` or `--crates`!".into())
         }
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -40,7 +40,7 @@ pub struct Update {
     #[structopt(long, short = "b")]
     beefy: bool,
 
-    /// Only alter BEEFY dependencies.
+    /// Alter polkadot, substrate + beefy dependencies
     #[structopt(long, short = "a")]
     all: bool,
 
@@ -76,7 +76,7 @@ impl Update {
 
         let rewrite = if self.all {
             if self.git.is_some() {
-                return Err("You need to pass `--substrate` or `--polkadot` for `--git`.".into());
+                return Err("You need to pass `--substrate`, `--polkadot` or `--beefy` for `--git`.".into());
             } else {
                 Rewrite::All
             }
@@ -84,8 +84,10 @@ impl Update {
             Rewrite::Substrate(self.git)
         } else if self.beefy {
             Rewrite::Beefy(self.git)
-        } else {
+        } else if self.polkadot {
             Rewrite::Polkadot(self.git)
+        } else {
+            return Err("You must specify one of `--substrate`, `--polkadot`, `--beefy` or `--all`.".into())
         };
 
         Ok((rewrite, version, self.path))

--- a/src/update.rs
+++ b/src/update.rs
@@ -10,6 +10,7 @@ enum Rewrite {
     All,
     Substrate(Option<String>),
     Polkadot(Option<String>),
+    Beefy(Option<String>),
 }
 
 /// The version the dependencies should be switched to.
@@ -34,6 +35,14 @@ pub struct Update {
     /// Only alter Polkadot dependencies.
     #[structopt(long, short = "p")]
     polkadot: bool,
+
+    /// Only alter BEEFY dependencies.
+    #[structopt(long, short = "b")]
+    beefy: bool,
+
+    /// Only alter BEEFY dependencies.
+    #[structopt(long, short = "a")]
+    all: bool,
 
     /// The `branch` that the dependencies should use.
     #[structopt(long, conflicts_with_all = &[ "rev", "tag" ])]
@@ -65,7 +74,7 @@ impl Update {
             return Err("You need to pass `--branch`, `--tag` or `--rev`".into());
         };
 
-        let rewrite = if self.substrate == self.polkadot {
+        let rewrite = if self.all {
             if self.git.is_some() {
                 return Err("You need to pass `--substrate` or `--polkadot` for `--git`.".into());
             } else {
@@ -73,6 +82,8 @@ impl Update {
             }
         } else if self.substrate {
             Rewrite::Substrate(self.git)
+        } else if self.beefy {
+            Rewrite::Beefy(self.git)
         } else {
             Rewrite::Polkadot(self.git)
         };
@@ -117,6 +128,7 @@ fn handle_dependency(dep: &mut InlineTable, rewrite: &Rewrite, version: &Version
         Rewrite::All => &None,
         Rewrite::Substrate(new_git) if git.name == "substrate" => new_git,
         Rewrite::Polkadot(new_git) if git.name == "polkadot" => new_git,
+        Rewrite::Beefy(new_git) if git.name == "grandpa-bridge-gadget" => new_git,
         _ => return,
     };
 


### PR DESCRIPTION
- Added a `--beefy` option for handling grandpa-bridge-gadget dependency handling
- Changed the behaviour when not providing one of `--polkadot`, `--substrate` (and now `--beefy`) to error (previous behaviour was implicit all)
- Added `--all` for patching all three dependencies
- Bumped the minor version since the behaviour when not specifying polkadot, substrate or beefy is a breaking change

I want to use Diener for handling our dependencies during releases (i.e., switching to the polkadot-v1.2.3 branches in substrate + beefy when we branch off for a polkadot release), so adding the `--beefy` option makes this a lot easier.

I'm still not so great with rust, and maybe I've done completely the wrong thing here :sweat_smile: 