### PR TITLE
add an error when the path to the cargo workspace is not a directory

### DIFF
--- a/src/update.rs
+++ b/src/update.rs
@@ -111,6 +111,9 @@ impl Update {
         let path = path.map(Ok).unwrap_or_else(|| {
             current_dir().map_err(|e| format!("Working directory is invalid: {:?}", e))
         })?;
+        if !path.is_dir() {
+            return Err(format!("Path '{}' is not a directory.", path.to_string_lossy()));
+        }
 
         let is_hidden = |entry: &DirEntry| {
             entry

--- a/src/update.rs
+++ b/src/update.rs
@@ -112,7 +112,7 @@ impl Update {
             current_dir().map_err(|e| format!("Working directory is invalid: {:?}", e))
         })?;
         if !path.is_dir() {
-            return Err(format!("Path '{}' is not a directory.", path.to_string_lossy()));
+            return Err(format!("Path '{}' is not a directory.", path.display()));
         }
 
         let is_hidden = |entry: &DirEntry| {


### PR DESCRIPTION
which would lead the 'update' command to fail silently